### PR TITLE
Implementing Processor-Complainer 

### DIFF
--- a/src/main/java/org/jboss/pull/processor/Main.java
+++ b/src/main/java/org/jboss/pull/processor/Main.java
@@ -32,6 +32,18 @@ public class Main {
             }
         }
 
+        // Run milestone processing
+        if (Boolean.getBoolean("complain")) {
+            try {
+                ProcessorComplainer processor = new ProcessorComplainer();
+                processor.run();
+                System.exit(0);
+            } catch (Exception e) {
+                System.err.println(e);
+                e.printStackTrace(System.err);
+            }
+        }
+
         System.err.println(usage());
         System.exit(1);
     }

--- a/src/main/java/org/jboss/pull/processor/ProcessorComplainer.java
+++ b/src/main/java/org/jboss/pull/processor/ProcessorComplainer.java
@@ -1,0 +1,66 @@
+package org.jboss.pull.processor;
+
+import java.util.List;
+
+import org.jboss.pull.shared.Util;
+import org.jboss.pull.shared.connectors.RedhatPullRequest;
+import org.jboss.pull.shared.connectors.bugzilla.Bug;
+import org.jboss.pull.shared.spi.PullEvaluator.Result;
+
+public class ProcessorComplainer extends Processor {
+
+    public ProcessorComplainer() throws Exception {
+    }
+
+    public void run() {
+        System.out.println("Starting at: " + Util.getTime());
+
+        try {
+            final List<RedhatPullRequest> pullRequests = helper.getOpenPullRequests();
+
+            for (RedhatPullRequest pullRequest : pullRequests) {
+                processPullRequest(pullRequest);
+            }
+        } finally {
+            System.out.println("Completed at: " + Util.getTime());
+        }
+    }
+
+    public void processPullRequest(RedhatPullRequest pullRequest) {
+        Result result = new Result();
+
+        System.out.println("ProcessComplainer processing PullRequest: " + pullRequest.getNumber() + " on repository: "
+                + pullRequest.getOrganization() + "/" + pullRequest.getRepository());
+
+        result = checkBugs(pullRequest, result);
+        if( pullRequest.isUpstreamRequired() ){
+            result = checkRelatedPullRequests(pullRequest, result);
+        }else{
+            System.out.println("Upstream not required");
+        }
+
+        complain(pullRequest, result.getDescription());
+    }
+
+    private Result checkBugs(RedhatPullRequest pullRequest, Result result) {
+        List<Bug> bugs = pullRequest.getBugs();
+        if (bugs.isEmpty() && pullRequest.isJiraInDescription()) {
+            System.out.println("Missing Bugzilla or JIRA link");
+            result.setMergeable(false);
+            result.addDescription("Missing Bugzilla or JIRA. Please add link to description");
+        }
+        return result;
+    }
+
+    private Result checkRelatedPullRequests(RedhatPullRequest pullRequest, Result result) {
+        List<RedhatPullRequest> relatedPullRequests = pullRequest.getRelatedPullRequests();
+        if (relatedPullRequests.isEmpty()) {
+            System.out.println("Missing Upstream");
+            result.setMergeable(false);
+            result.addDescription("Missing Upstream. Please add link to description or indicate 'No upstream required'");
+        }
+        return result;
+
+    }
+
+}

--- a/src/main/java/org/jboss/pull/processor/ProcessorMerge.java
+++ b/src/main/java/org/jboss/pull/processor/ProcessorMerge.java
@@ -7,7 +7,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.egit.github.core.Comment;
 import org.jboss.pull.shared.ProcessorPullState;
 import org.jboss.pull.shared.Util;
 import org.jboss.pull.shared.connectors.RedhatPullRequest;
@@ -233,27 +232,6 @@ public class ProcessorMerge extends Processor {
             } catch (Throwable t) {
             }
         }
-    }
-
-    private void complain(RedhatPullRequest pullRequest, List<String> description) {
-        final String pattern = "cannot be merged due to non-compliance with the rules";
-        final StringBuilder comment = new StringBuilder("This PR ").append(pattern).append(" of the relevant EAP version.\n");
-        comment.append("details:\n");
-        for (String detailDesc : description) {
-            comment.append(detailDesc).append("\n");
-        }
-
-        boolean postIt = true;
-
-        final List<Comment> comments = pullRequest.getGithubComments();
-        if (!comments.isEmpty()) {
-            final Comment lastComment = comments.get(comments.size() - 1);
-            if (lastComment.getBody().indexOf(pattern) != -1)
-                postIt = false;
-        }
-
-        if (postIt)
-            postComment(pullRequest, comment.toString());
     }
 
     private void postStatus(RedhatPullRequest pull, int buildNumber, String status) {


### PR DESCRIPTION
Parses github PR description for a BZ or JIRA link and complains if one is not found.

Parses github PR description for a PR link, assumed to be upstream, or 'no upstream required' pattern. Complains if not found.

Doesn't re-complain if the complaint has not changed. Does not post anything if there are no complaints.
