### PR TITLE
tiny change in detail message.

### DIFF
--- a/src/main/java/org/jboss/pull/processor/ProcessorComplainer.java
+++ b/src/main/java/org/jboss/pull/processor/ProcessorComplainer.java
@@ -41,7 +41,7 @@ public class ProcessorComplainer extends Processor {
         if (!areBugLinksInDescription(pullRequest)) {
             System.out.println("Missing Bugzilla or JIRA link");
             result.setMergeable(false);
-            result.addDescription("Missing Bugzilla or JIRA. Please add link to description");
+            result.addDescription("Missing Bugzilla/JIRA or Target Release/Fix Versions are incompatible. Please add link to description");
         }
         return result;
     }


### PR DESCRIPTION
PR owners might think that they have correct BZs in description, But If their Target Release / Fix Versions are incorrect or unset, processor can't recognize these BZs, complain this may help to let them check these values. 
